### PR TITLE
Checkout the staging tag prior to creating the production tag

### DIFF
--- a/lib/capistrano/tasks/git_tags.rake
+++ b/lib/capistrano/tasks/git_tags.rake
@@ -38,7 +38,7 @@ namespace :gittags do
           ask :a_description_of_what_you_are_deploying, "latest changes"
 
           safe_tag = fetch(:a_description_of_what_you_are_deploying).downcase.gsub(/[^a-z0-9]/, "-").gsub(/staging/, "stage")
-          staging_tag = "staging-#{time.year}-#{time.strftime('%m')}-#{time.strftime('%d')}-#{time.strftime('%H')}-#{time.strftime('%M')}-#{safe_tag}"
+          staging_tag = "staging-#{time.strftime('%Y-%m-%d-%H-%M')}-#{safe_tag}"
 
           info "Publishing tag: #{staging_tag}"
           Capistrano::GitTags::Helper.publish_tag staging_tag

--- a/lib/capistrano/tasks/git_tags.rake
+++ b/lib/capistrano/tasks/git_tags.rake
@@ -22,6 +22,9 @@ namespace :gittags do
             abort "You didn't confirm the deployment"
           end
 
+          info "Checking out '#{latest_staging_tag}' locally"
+          Capistrano::GitTags::Helper.git "checkout #{latest_staging_tag}"
+
           unless ENV['TAG']
             info "Publishing tag: #{production_tag}"
             Capistrano::GitTags::Helper.publish_tag production_tag
@@ -34,8 +37,8 @@ namespace :gittags do
 
           ask :a_description_of_what_you_are_deploying, "latest changes"
 
-          safe_tag = fetch(:a_description_of_what_you_are_deploying).downcase.gsub(/[^a-z0-9]/, "-")
-          staging_tag = "staging-#{time.year}-#{time.month}-#{time.day}-#{time.hour}-#{time.min}-#{safe_tag}"
+          safe_tag = fetch(:a_description_of_what_you_are_deploying).downcase.gsub(/[^a-z0-9]/, "-").gsub(/staging/, "stage")
+          staging_tag = "staging-#{time.year}-#{time.strftime('%m')}-#{time.strftime('%d')}-#{time.strftime('%H')}-#{time.strftime('%M')}-#{safe_tag}"
 
           info "Publishing tag: #{staging_tag}"
           Capistrano::GitTags::Helper.publish_tag staging_tag


### PR DESCRIPTION
This PR primarily addresses issue #4.

It checks out the most recent staging tag prior to creating the production tag;

I have prevented the word `staging` from being used in the staging tag description (updates it to 'stage') so that you can grep the tags for `staging-` without catching other tags;

I have also changed the staging tag to use padded date/time values, in order to fix sorting issues seen with `git describe --abbrev=0 --tags --match="staging-*"`.
